### PR TITLE
availability check: changes related to default values and dates validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ INSERT INTO `Island`.`Configuration` (`Name`, `Description`, `Value`) VALUES ('M
 
 INSERT INTO `Island`.`Configuration` (`Name`, `Description`, `Value`) VALUES ('MAX_DATE_RANGE', 'Max number of days to query for availability', '90');
 
+INSERT INTO `Island`.`Configuration` (`Name`, `Description`, `Value`) VALUES ('DEFAULT_DATE_RANGE', 'Default number of days to query for availability', '30');
+
 
 -- view with dates used to lock before creating/updating DayAvailability records
 

--- a/src/main/java/com/upgrade/islandreservationsapi/controller/AvailabilityController.java
+++ b/src/main/java/com/upgrade/islandreservationsapi/controller/AvailabilityController.java
@@ -3,8 +3,11 @@ package com.upgrade.islandreservationsapi.controller;
 import com.upgrade.islandreservationsapi.dto.DayAvailabilityDTO;
 import com.upgrade.islandreservationsapi.exception.InvalidDatesException;
 import com.upgrade.islandreservationsapi.model.DayAvailability;
+import com.upgrade.islandreservationsapi.service.ConfigurationService;
 import com.upgrade.islandreservationsapi.service.DayAvailabilityService;
 import io.swagger.annotations.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,7 +26,14 @@ import java.util.stream.Collectors;
 public class AvailabilityController {
 
     @Autowired
-    private DayAvailabilityService service;
+    private DayAvailabilityService availabilityService;
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private final Logger logger = LogManager.getLogger(AvailabilityController.class);
 
     @GetMapping(path = "v1/availability", produces = "application/json; charset=utf-8")
     @ResponseBody
@@ -38,12 +49,16 @@ public class AvailabilityController {
             @RequestParam(name = "toDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate toDate)
             throws InvalidDatesException {
         if(fromDate == null) {
-            fromDate = LocalDate.now().plusDays(1);
+            int minAheadDays = configurationService.getMinAheadDays();
+            fromDate = LocalDate.now().plusDays(minAheadDays);
+            logger.debug("fromDate not provided. using default value: {}", fromDate.format(formatter));
         }
         if(toDate == null) {
-            toDate = fromDate.plusMonths(1);
+            int defaultRange = configurationService.getDefaultDateRange();
+            toDate = fromDate.plusDays(defaultRange).minusDays(1);
+            logger.debug("toDate not provided. using default value {}", toDate.format(formatter));
         }
-        List<DayAvailability> availabilities = service.getAvailabilities(fromDate, toDate);
+        List<DayAvailability> availabilities = availabilityService.getAvailabilities(fromDate, toDate);
         final ModelMapper mapper = new ModelMapper();
         return availabilities.stream()
                 .map(da -> mapper.map(da, DayAvailabilityDTO.class))

--- a/src/main/java/com/upgrade/islandreservationsapi/model/Configuration.java
+++ b/src/main/java/com/upgrade/islandreservationsapi/model/Configuration.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 @Table(name = "Configuration")
 public class Configuration {
 
-    public enum CONFIGURATION_NAMES {MAX_AVAILABILITY, MAX_RESERVATION, MIN_AHEAD, MAX_AHEAD, MAX_DATE_RANGE}
+    public enum CONFIGURATION_NAMES {MAX_AVAILABILITY, MAX_RESERVATION, MIN_AHEAD, MAX_AHEAD, MAX_DATE_RANGE, DEFAULT_DATE_RANGE}
 
     @Column(name = "Name")
     @NotNull

--- a/src/main/java/com/upgrade/islandreservationsapi/service/ConfigurationService.java
+++ b/src/main/java/com/upgrade/islandreservationsapi/service/ConfigurationService.java
@@ -38,4 +38,12 @@ public interface ConfigurationService {
      * @return int with max date range for availability check
      */
     int getMaxDateRange();
+
+    /**
+     * Gets the default number of days to check for availability when no parameters are provided
+     * in the API call.
+     * If this configuration record does not exist, inserts a new one with a default value
+     * @return int with default date range for availability check
+     */
+    int getDefaultDateRange();
 }

--- a/src/main/java/com/upgrade/islandreservationsapi/service/DayAvailabilityServiceImpl.java
+++ b/src/main/java/com/upgrade/islandreservationsapi/service/DayAvailabilityServiceImpl.java
@@ -49,12 +49,9 @@ public class DayAvailabilityServiceImpl implements DayAvailabilityService {
             throw new InvalidDatesException("toDate must be after fromDate.");
         }
         long maxDateRange = configurationService.getMaxDateRange();
-        if(maxDateRange % 30 == 0) {
-            // if max date range is 30, then treat it as a month. so update it based on this month's number of days
-            maxDateRange = ChronoUnit.DAYS.between(fromDate, LocalDate.now().plusMonths(1).plusDays(1));
-        }
-        if(ChronoUnit.DAYS.between(fromDate, toDate) >= maxDateRange) {
-            logger.info("getAvailabilities(): Invalid dates. Date range is too long.");
+        int range = (int) ChronoUnit.DAYS.between(fromDate, toDate.plusDays(1));
+        if(range > maxDateRange) {
+            logger.info("getAvailabilities(): Invalid dates. Date range {} is greater than the max {}", range, maxDateRange);
             throw new InvalidDatesException("Date range is too long. Please send a date range of " + maxDateRange + " days max.");
         }
         if(!fromDate.isAfter(LocalDate.now())) {

--- a/src/main/java/com/upgrade/islandreservationsapi/service/ReservationServiceImpl.java
+++ b/src/main/java/com/upgrade/islandreservationsapi/service/ReservationServiceImpl.java
@@ -41,7 +41,7 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Reservation createReservation(Reservation reservation) throws NoAvailabilityForDateException {
-        logger.debug("createReservation(): updating uvalability...");
+        logger.debug("createReservation(): updating avalability...");
         availabilityService.updateDayAvailability(reservation);
         logger.info("Creating reservation {}", reservation.toString());
         return reservationRepository.save(reservation);

--- a/src/test/java/com/upgrade/islandreservationsapi/integration/DayAvailabilityControllerIntegrationTest.java
+++ b/src/test/java/com/upgrade/islandreservationsapi/integration/DayAvailabilityControllerIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.upgrade.islandreservationsapi.integration;
+
+import com.upgrade.islandreservationsapi.service.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@RunWith(SpringRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class DayAvailabilityControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ConfigurationService configService;
+
+    private int defaultRange;
+    private  int maxRange;
+    private int minAheadDays;
+
+    @Before
+    public void init() {
+        defaultRange = configService.getDefaultDateRange();
+        maxRange = configService.getMaxDateRange();
+        minAheadDays = configService.getMinAheadDays();
+    }
+
+    @Test
+    public void getAvailabilitiesNoParameters() throws Exception {
+
+        mvc.perform(get("/v1/availability")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(defaultRange)));
+    }
+
+    @Test
+    public void getAvailabilitiesValidRange() throws Exception {
+        LocalDate d1 = LocalDate.now().plusDays(minAheadDays);
+        LocalDate d2 = d1.plusDays(maxRange - 1);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        mvc.perform(get("/v1/availability?fromDate=" + d1.format(formatter) + "&toDate=" + d2.format(formatter))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(maxRange)));
+    }
+
+    @Test
+    public void getAvailabilitiesInvalidRange() throws Exception {
+
+        LocalDate d1 = LocalDate.now().plusDays(minAheadDays);
+        LocalDate d2 = d1.plusDays(maxRange);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        mvc.perform(get("/v1/availability?fromDate=" + d1.format(formatter) + "&toDate=" + d2.format(formatter))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8"))
+                .andExpect(status().isBadRequest());
+    }
+
+}

--- a/src/test/java/com/upgrade/islandreservationsapi/integration/ReservationControllerIntegrationTest.java
+++ b/src/test/java/com/upgrade/islandreservationsapi/integration/ReservationControllerIntegrationTest.java
@@ -47,8 +47,8 @@ public class ReservationControllerIntegrationTest {
 
     @Autowired
     private DayAvailabilityRepository availabilityRepository;
-    private final Logger logger = LogManager.getLogger(ReservationControllerIntegrationTest.class);
 
+    private final Logger logger = LogManager.getLogger(ReservationControllerIntegrationTest.class);
 
     @Test
     public void testGetReservation() throws Exception {

--- a/src/test/java/com/upgrade/islandreservationsapi/service/DayAvailabilityServiceTest.java
+++ b/src/test/java/com/upgrade/islandreservationsapi/service/DayAvailabilityServiceTest.java
@@ -21,7 +21,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -53,11 +52,15 @@ public class DayAvailabilityServiceTest {
 
     private static final int DEFAULT_MAX_AVAILABILITY = 100;
     private static final int DEFAULT_MAX_DATE_RANGE = 30;
+    private static final int DEFAULT_MIN_AHEAD_DAYS = 1;
+    private static final int DEFAULT_DEFAULT_DATE_RANGE = 30;
 
     @Before
     public void init() {
         Mockito.when(configurationService.getMaxAvailability()).thenReturn(DEFAULT_MAX_AVAILABILITY);
         Mockito.when(configurationService.getMaxDateRange()).thenReturn(DEFAULT_MAX_DATE_RANGE);
+        Mockito.when(configurationService.getMinAheadDays()).thenReturn(DEFAULT_MIN_AHEAD_DAYS);
+        Mockito.when(configurationService.getDefaultDateRange()).thenReturn(DEFAULT_DEFAULT_DATE_RANGE);
 
         List<Dates> dates = new ArrayList<>();
         LocalDate.now().datesUntil(LocalDate.now().plusDays(30)).forEach(d -> dates.add(new Dates(d)));
@@ -75,16 +78,16 @@ public class DayAvailabilityServiceTest {
 
     @Test(expected = InvalidDatesException.class)
     public void testGetAvailabilityInvalidDates2() throws InvalidDatesException {
-        LocalDate fromDate = LocalDate.now().plusDays(1);
-        LocalDate toDate = LocalDate.now().plusDays(32);
+        LocalDate fromDate = LocalDate.now().plusDays(DEFAULT_MIN_AHEAD_DAYS);
+        LocalDate toDate = fromDate.plusDays(DEFAULT_MAX_DATE_RANGE);
 
         availabilityService.getAvailabilities(fromDate, toDate);
     }
 
     @Test
     public void testGetAvailabilityValidDates() throws InvalidDatesException {
-        LocalDate fromDate = LocalDate.now().plusDays(1);
-        LocalDate toDate = LocalDate.now().plusDays(31);
+        LocalDate fromDate = LocalDate.now().plusDays(DEFAULT_MIN_AHEAD_DAYS);
+        LocalDate toDate = fromDate.plusDays(DEFAULT_MAX_DATE_RANGE - 1);
 
         availabilityService.getAvailabilities(fromDate, toDate);
     }


### PR DESCRIPTION
configuration MIN_AHEAD_DAYS is used to define default value for fromDate when checking availability
added configuration DEFAULT_DATE_RANGE with the default number of days used for availability check when toDate is not provided
updated ConfigurationServiceImpl to update the value of properties with number of days when value is multiple of 30 to treat it as months. for example, value of 30 is changed to 31 when current month has 31 days.
reformatted code in ConfigurationServiceImpl to avoid code duplication
fixed bug in availability check: value update of max availability was set to one month even if property value was for example 90 days.
added availability check integration tests